### PR TITLE
Add link checker action

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -1,0 +1,24 @@
+name: Links
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+
+jobs:
+  check-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v1.8.0
+        with:
+          args: --verbose --no-progress './**/*.md' './**/*.html' --exclude-all-private --exclude 'file:///*'
+
+      - name: Create Issue From File
+        if: env.lychee_exit_code != 0
+        uses: peter-evans/create-issue-from-file@v4
+        with:
+          title: Link Checker Report
+          content-filepath: ./lychee/out.md
+          labels: good first issue, bug


### PR DESCRIPTION
Add a gh workflow that checks all external links daily and creates issues if any are not working

Fixes: https://github.com/FidelusAleksander/githubcertified/issues/48