### PR TITLE
Remove submodule dependabot as it doesnt support tag granularity

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,3 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-  - package-ecosystem: "gitsubmodule"
-    directory: "/"
-    schedule:
-      interval: "weekly"


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Content changes (add/update questions, answers, explanations)
- [ ] Bugfix
- [ ] Feature
- [ ] Refactor (no functional changes)
- [ ] Documentation changes
- [x] Other


## What's new?
<!-- Describe what this PR changes -->
Remove submodule from dependabot as it always wants to update to latest commit, which may be unstable.
Tag granularity not supported 

## Related issue(s)
<!-- If applicable link to related issues -->
https://github.com/dependabot/dependabot-core/issues/1639

## Screenshots
<!-- (optional) Include related screenshots -->
