### PR TITLE
fix: Shuffle answers as default so they are shuffled in questions tab

### DIFF
--- a/layouts/partials/quizdown.html
+++ b/layouts/partials/quizdown.html
@@ -10,7 +10,7 @@ src="https://cdn.jsdelivr.net/npm/quizdown@latest/public/build/extensions/quizdo
 <script>
     let config = {
         startOnLoad: true,          // detect and convert all div html elements with class quizdown
-        shuffleAnswers: {{ with .Page.Params.shuffleAnswers }} {{ . }} {{ else }} false {{ end }},      // shuffle answers for each question
+        shuffleAnswers: {{ with .Page.Params.shuffleAnswers }} {{ . }} {{ else }} true {{ end }},      // shuffle answers for each question
         shuffleQuestions: {{ with .Page.Params.shuffleQuestions }} {{ . }} {{ else }} false {{ end }},    // shuffle questions for each quiz
         nQuestions: {{ with .Page.Params.nQuestions }} {{ . }} {{ else }} undefined {{ end }},      // display n questions at random, if shuffleQuestions is true
         primaryColor: 'steelblue',  // primary CSS color


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Content changes (add/update questions, answers, explanations)
- [x] Bugfix
- [ ] Feature
- [ ] Refactor (no functional changes)
- [ ] Documentation changes
- [ ] Other


## What's new?
<!-- Describe what this PR changes -->
Questions in question tab were not shuffled, therefore the first answers were always correct

## Related issue(s)
<!-- If applicable link to related issues -->

## Screenshots
<!-- (optional) Include related screenshots -->
